### PR TITLE
Add narrative relation module

### DIFF
--- a/cf_ded_narrative_relation/__init__.py
+++ b/cf_ded_narrative_relation/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/cf_ded_narrative_relation/__manifest__.py
+++ b/cf_ded_narrative_relation/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    "name": "cf_ded_narrative_relation",
+    "version": "17.0.1.0.0",
+    "license": "AGPL-3",
+    "depends": ["base", "mail"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/narrative_relation_views.xml",
+        "views/narrative_relation_buttons.xml",
+    ],
+    "application": False,
+}

--- a/cf_ded_narrative_relation/models/__init__.py
+++ b/cf_ded_narrative_relation/models/__init__.py
@@ -1,0 +1,1 @@
+from . import narrative_relation

--- a/cf_ded_narrative_relation/models/narrative_relation.py
+++ b/cf_ded_narrative_relation/models/narrative_relation.py
@@ -1,0 +1,134 @@
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class NarrativeRelation(models.Model):
+    _name = "ded.narrative.relation"
+    _description = "Narrative Relation"
+    _inherit = ["mail.thread"]
+
+    description = fields.Text(required=True, tracking=True)
+    source_ref = fields.Reference(
+        selection="_selection_reference_models", required=True, tracking=True
+    )
+    source_model = fields.Many2one("ir.model", required=True, index=True)
+    source_id = fields.Integer(required=True, index=True)
+    target_ref = fields.Reference(
+        selection="_selection_reference_models", required=True, tracking=True
+    )
+    target_model = fields.Many2one("ir.model", required=True, index=True)
+    target_id = fields.Integer(required=True, index=True)
+    is_directional = fields.Boolean(default=True)
+    name = fields.Char(compute="_compute_name", store=True)
+
+    _sql_constraints = [
+        (
+            "no_self_link",
+            "CHECK(source_model_id != target_model_id OR source_id != target_id)",
+            "Source and target must be different.",
+        )
+    ]
+
+    @api.depends("source_ref", "target_ref")
+    def _compute_name(self):
+        for record in self:
+            source_name = record.source_ref.display_name if record.source_ref else ""
+            target_name = record.target_ref.display_name if record.target_ref else ""
+            record.name = f"{source_name} → {target_name}"
+
+    @api.onchange("source_ref")
+    def _onchange_source_ref(self):
+        for record in self:
+            if record.source_ref:
+                record.source_model = self.env["ir.model"]._get(record.source_ref._name)
+                record.source_id = record.source_ref.id
+            else:
+                record.source_model = False
+                record.source_id = False
+
+    @api.onchange("target_ref")
+    def _onchange_target_ref(self):
+        for record in self:
+            if record.target_ref:
+                record.target_model = self.env["ir.model"]._get(record.target_ref._name)
+                record.target_id = record.target_ref.id
+            else:
+                record.target_model = False
+                record.target_id = False
+
+    @api.model
+    def _get_allowed_model_names(self):
+        param = (
+            self.env["ir.config_parameter"].sudo().get_param(
+                "ded.narrative.allowed_models", ""
+            )
+        )
+        if param:
+            return {m.strip() for m in param.split(",") if m.strip()}
+        return set(
+            self.env["ir.model"]
+            .sudo()
+            .search([("transient", "=", False)])
+            .mapped("model")
+        )
+
+    @api.model
+    def _selection_reference_models(self):
+        allowed = sorted(self._get_allowed_model_names())
+        models = self.env["ir.model"].sudo().search([("model", "in", allowed)])
+        return [(m.model, m.name) for m in models]
+
+    def _validate_allowed_models(self, model_names):
+        allowed = self._get_allowed_model_names()
+        if allowed:
+            for model_name in model_names:
+                if model_name not in allowed:
+                    raise ValidationError(
+                        _("Model %s is not allowed for narrative relations.")
+                        % model_name
+                    )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get("source_ref") and (
+                not vals.get("source_model") or not vals.get("source_id")
+            ):
+                model_name, res_id = vals["source_ref"].split(",")
+                vals["source_model"] = self.env["ir.model"]._get(model_name).id
+                vals["source_id"] = int(res_id)
+            if vals.get("target_ref") and (
+                not vals.get("target_model") or not vals.get("target_id")
+            ):
+                model_name, res_id = vals["target_ref"].split(",")
+                vals["target_model"] = self.env["ir.model"]._get(model_name).id
+                vals["target_id"] = int(res_id)
+            source_model_name = (
+                self.env["ir.model"].browse(vals["source_model"]).model
+                if vals.get("source_model")
+                else False
+            )
+            target_model_name = (
+                self.env["ir.model"].browse(vals["target_model"]).model
+                if vals.get("target_model")
+                else False
+            )
+            self._validate_allowed_models([source_model_name, target_model_name])
+        return super().create(vals_list)
+
+    def write(self, vals):
+        if "source_ref" in vals:
+            model_name, res_id = vals["source_ref"].split(",")
+            vals["source_model"] = self.env["ir.model"]._get(model_name).id
+            vals["source_id"] = int(res_id)
+        if "target_ref" in vals:
+            model_name, res_id = vals["target_ref"].split(",")
+            vals["target_model"] = self.env["ir.model"]._get(model_name).id
+            vals["target_id"] = int(res_id)
+        for record in self:
+            source_model_id = vals.get("source_model", record.source_model.id)
+            target_model_id = vals.get("target_model", record.target_model.id)
+            source_model_name = self.env["ir.model"].browse(source_model_id).model
+            target_model_name = self.env["ir.model"].browse(target_model_id).model
+            self._validate_allowed_models([source_model_name, target_model_name])
+        return super().write(vals)

--- a/cf_ded_narrative_relation/security/ir.model.access.csv
+++ b/cf_ded_narrative_relation/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_ded_narrative_relation,access_ded_narrative_relation,model_ded_narrative_relation,base.group_user,1,1,1,1

--- a/cf_ded_narrative_relation/views/narrative_relation_buttons.xml
+++ b/cf_ded_narrative_relation/views/narrative_relation_buttons.xml
@@ -1,0 +1,85 @@
+<odoo>
+    <!-- creature.faction -->
+    <record id="action_narrative_relation_creature_faction" model="ir.actions.act_window">
+        <field name="name">Relazioni</field>
+        <field name="res_model">ded.narrative.relation</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">['|',
+            '&amp;', ('source_model', '=', ref('base.model_creature_faction')), ('source_id', '=', active_id),
+            '&amp;', ('target_model', '=', ref('base.model_creature_faction')), ('target_id', '=', active_id)
+        ]</field>
+    </record>
+    <record id="view_creature_faction_form_narrative_button" model="ir.ui.view">
+        <field name="name">creature.faction.form.narrative.button</field>
+        <field name="model">creature.faction</field>
+        <field name="inherit_id" ref="cf_ded_base.creature_faction_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//sheet/group[1]" position="before">
+                <button type="action" name="%(action_narrative_relation_creature_faction)d" string="Relazioni"/>
+            </xpath>
+        </field>
+    </record>
+
+    <!-- creature.npc -->
+    <record id="action_narrative_relation_creature_npc" model="ir.actions.act_window">
+        <field name="name">Relazioni</field>
+        <field name="res_model">ded.narrative.relation</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">['|',
+            '&amp;', ('source_model', '=', ref('base.model_creature_npc')), ('source_id', '=', active_id),
+            '&amp;', ('target_model', '=', ref('base.model_creature_npc')), ('target_id', '=', active_id)
+        ]</field>
+    </record>
+    <record id="view_creature_npc_form_narrative_button" model="ir.ui.view">
+        <field name="name">creature.npc.form.narrative.button</field>
+        <field name="model">creature.npc</field>
+        <field name="inherit_id" ref="cf_ded_base.creature_npc_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//sheet/group[1]" position="before">
+                <button type="action" name="%(action_narrative_relation_creature_npc)d" string="Relazioni"/>
+            </xpath>
+        </field>
+    </record>
+
+    <!-- structure.structure -->
+    <record id="action_narrative_relation_structure_structure" model="ir.actions.act_window">
+        <field name="name">Relazioni</field>
+        <field name="res_model">ded.narrative.relation</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">['|',
+            '&amp;', ('source_model', '=', ref('base.model_structure_structure')), ('source_id', '=', active_id),
+            '&amp;', ('target_model', '=', ref('base.model_structure_structure')), ('target_id', '=', active_id)
+        ]</field>
+    </record>
+    <record id="view_structure_structure_form_narrative_button" model="ir.ui.view">
+        <field name="name">structure.structure.form.narrative.button</field>
+        <field name="model">structure.structure</field>
+        <field name="inherit_id" ref="cf_ded_base.structure_structure_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//sheet/group[1]" position="before">
+                <button type="action" name="%(action_narrative_relation_structure_structure)d" string="Relazioni"/>
+            </xpath>
+        </field>
+    </record>
+
+    <!-- campaign.mission -->
+    <record id="action_narrative_relation_campaign_mission" model="ir.actions.act_window">
+        <field name="name">Relazioni</field>
+        <field name="res_model">ded.narrative.relation</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">['|',
+            '&amp;', ('source_model', '=', ref('base.model_campaign_mission')), ('source_id', '=', active_id),
+            '&amp;', ('target_model', '=', ref('base.model_campaign_mission')), ('target_id', '=', active_id)
+        ]</field>
+    </record>
+    <record id="view_campaign_mission_form_narrative_button" model="ir.ui.view">
+        <field name="name">campaign.mission.form.narrative.button</field>
+        <field name="model">campaign.mission</field>
+        <field name="inherit_id" ref="cf_ded_campaign.campaign_mission_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//sheet/group[1]" position="before">
+                <button type="action" name="%(action_narrative_relation_campaign_mission)d" string="Relazioni"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/cf_ded_narrative_relation/views/narrative_relation_views.xml
+++ b/cf_ded_narrative_relation/views/narrative_relation_views.xml
@@ -1,0 +1,54 @@
+<odoo>
+    <record id="view_narrative_relation_tree" model="ir.ui.view">
+        <field name="name">ded.narrative.relation.tree</field>
+        <field name="model">ded.narrative.relation</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="source_ref"/>
+                <field name="description"/>
+                <field name="target_ref"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_narrative_relation_form" model="ir.ui.view">
+        <field name="name">ded.narrative.relation.form</field>
+        <field name="model">ded.narrative.relation</field>
+        <field name="arch" type="xml">
+            <form string="Narrative Relation">
+                <sheet>
+                    <group>
+                        <field name="source_ref"/>
+                        <field name="target_ref"/>
+                        <field name="is_directional"/>
+                    </group>
+                    <group>
+                        <field name="description" placeholder="Testo della relazione..." colspan="4"/>
+                    </group>
+                </sheet>
+                <div class="oe_chatter"/>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_narrative_relation_search" model="ir.ui.view">
+        <field name="name">ded.narrative.relation.search</field>
+        <field name="model">ded.narrative.relation</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="description"/>
+                <filter string="Per modello origine" context="{'group_by': 'source_model'}"/>
+                <filter string="Per modello destinazione" context="{'group_by': 'target_model'}"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_ded_narrative_relation" model="ir.actions.act_window">
+        <field name="name">Relazioni narrative</field>
+        <field name="res_model">ded.narrative.relation</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="menu_ded_narrative_root" name="Narrazione" parent="cf_ded_base.menu_root"/>
+    <menuitem id="menu_ded_narrative_relation" name="Relazioni" parent="menu_ded_narrative_root" action="action_ded_narrative_relation"/>
+</odoo>


### PR DESCRIPTION
## Summary
- add cf_ded_narrative_relation module to manage directional narrative links between records
- provide views, menu, security and smart buttons on core models

## Testing
- `python -m py_compile cf_ded_narrative_relation/models/narrative_relation.py`
- ⚠️ `pip install 'odoo==17.0.*'` (package not available)


------
https://chatgpt.com/codex/tasks/task_e_689efa7a268083239a182c1a20157627